### PR TITLE
corrected install-flowpilot-desktop

### DIFF
--- a/scripts/install-flowpilot-desktop
+++ b/scripts/install-flowpilot-desktop
@@ -40,15 +40,17 @@ sdkmanager --install "platform-tools"
 sdkmanager --install "build-tools;32.0.0"
 
 # get python 3.9
-DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tzdata
 sudo apt install -y software-properties-common
 yes | sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt install -y python3.9 python3.9-dev python3.9-distutils 
+sudo apt install -y python3.9 python3.9-dev python3.9-distutils python3-pip scons
 
 # get flowpilot
 cd ~/ && git clone https://github.com/flowdriveai/flowpilot.git
 cd flowpilot && git submodule update --init
 
-pip install pipenv
+pip install pipenv numpy pycryptodome
+
+source ~/.bashrc
 
 success "Flowpilot successfully installed." 


### PR DESCRIPTION
Line 43: added "sudo" as "apt-get" needs root access
Line 46: added "python3-pip" as pip is used later in the script
Line 46 (edit 2): added "scons" as it is used after running "pipenv shell" in the second part of the installation
Line 52: added "numpy pycryptodome" as they are used by scons later
Line 54: added "source ~/.bashrc" to refresh the session for the addition of "pipenv" to the PATH

Without these edits the script does not execute correctly on a fresh minimal install of Ubuntu 20.04

Steps to replicate to validate claims: follow install directions for desktop in the wiki, on a fresh install of Ubuntu 20.04 minimal or later.