### PR TITLE
Fixed errors on thermald and controlsd

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -93,7 +93,7 @@ class Controls:
       # Fake: pandaStates, peripheralState, driverMonitoringState
       # See liveLocationKalman, liveParameters
       self.sm = messaging.SubMaster(['deviceState', 'pandaStates', 'peripheralState', 'modelV2', 'liveCalibration',
-                                     'driverMonitoringState', 'longitudinalPlan', 'lateralPlan', 'liveLocationKalman',
+                                     'driverMonitoringState', 'driverState', 'longitudinalPlan', 'lateralPlan', 'liveLocationKalman',
                                      'managerState', 'liveParameters', 'radarState'] + self.camera_packets + joystick_packet,
                                       ignore_alive=ignore, ignore_avg_freq=['radarState', 'longitudinalPlan', 'liveParameters',
                                                                             'liveLocationKalman'])

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -91,7 +91,7 @@ def set_offroad_alert_if_changed(offroad_alert: str, show_alert: bool, extra_tex
 
 def thermald_thread(end_event, hw_queue):
   pm = messaging.PubMaster(['deviceState'])
-  sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "controlsState", "pandaStates"], poll=["pandaStates"])
+  sm = messaging.SubMaster(["driverMonitoringState", "driverState","peripheralState", "gpsLocationExternal", "controlsState", "pandaStates"], poll=["pandaStates"])
 
   count = 0
 


### PR DESCRIPTION
Got three errors in total while running dummy_publishers.py.

In thermald.py ``sm = messaging.SubMaster`` was missing ``driverMonitoringState`` and ``driverState``
and in controlsd.py was missing ``driverState`` from ``self.sm = messaging.SubMaster``