### PR TITLE
changed Ubuntu to dynamic jammy downloader

### DIFF
--- a/scripts/flowpilot-setup-env-android
+++ b/scripts/flowpilot-setup-env-android
@@ -2,9 +2,7 @@
 
 set -e
 
-PROOT_DISTRO_NAME="ubuntu-jammy-fd"
-PROOT_DISTRO_URL="https://github.com/flowdriveai/flowpilot/releases/download/ubuntu-rootfs-pin-0/ubuntu-22.04-aarch64-pd-v4.7.0.tar.xz"
-PROOT_DISTRO_CHECKSUM="f705f2bb3bce63ee3bbd35caa3a55842564b6b7e1212b91373c4d999ffd1ff76"
+PROOT_DISTRO_NAME="ubuntu"
 
 
 # White
@@ -36,24 +34,52 @@ add_to_file() {
 }
 
 patch_proot_distro() {
-    # Add self-built ubuntu 22.04 aarch64 rootfs
-    cat > $PREFIX/etc/proot-distro/$PROOT_DISTRO_NAME.sh <<- EOF
+
+    # Script to overwrite and update proot ubuntu.sh file based on a template and SHA256SUMS file downloaded from a URL
+
+    # Define the URL to download the SHA256SUMS file
+    SHA256SUMS_URL="https://partner-images.canonical.com/core/jammy/current/SHA256SUMS"
+    # Define the path to the ubuntu.sh file (using the provided location)
+    UBUNTU_SH_FILE="${PREFIX}/etc/proot-distro/ubuntu.sh"
+
+    # Download the SHA256SUMS file
+    echo "Downloading SHA256SUMS file..."
+    curl -o SHA256SUMS "$SHA256SUMS_URL"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to download SHA256SUMS file!"
+        exit 1
+    fi
+    echo "SHA256SUMS file downloaded."
+
+    # Create an associative array to store SHA256 values from SHA256SUMS file
+    declare -A sha256_map
+
+    # Read SHA256SUMS file and populate the array
+    while read -r line; do
+        sha256=$(echo "$line" | awk '{print $1}')
+        filename=$(echo "$line" | awk '{print $2}' | sed 's/^\*//')
+        sha256_map["$filename"]="$sha256"
+    done < SHA256SUMS
+
+    # Overwrite the ubuntu.sh file with the new content based on the template below
+    cat > "$UBUNTU_SH_FILE" <<- EOF
     # This is a default distribution plug-in.
-    # Do not modify this file as your changes will be overwritten on the next update.
-    # If you want to customize installation, please make a copy.
+    # Do not modify this file as your changes will be overwritten on next update.
+    # If you want customize installation, please make a copy.
+    DISTRO_NAME="Ubuntu Jammy (current)"
 
-    DISTRO_NAME="Ubuntu"
-    DISTRO_COMMENT="Standard release (jammy). Not available for x86 32-bit (i686) CPUs."
+    TARBALL_URL['aarch64']="https://partner-images.canonical.com/core/jammy/current/ubuntu-jammy-core-cloudimg-arm64-root.tar.gz"
+    TARBALL_SHA256['aarch64']="${sha256_map[ubuntu-jammy-core-cloudimg-arm64-root.tar.gz]}"
+    TARBALL_STRIP_OPT=0
+    TARBALL_URL['arm']="https://partner-images.canonical.com/core/jammy/current/ubuntu-jammy-core-cloudimg-armhf-root.tar.gz"
+    TARBALL_SHA256['arm']="${sha256_map[ubuntu-jammy-core-cloudimg-armhf-root.tar.gz]}"
+    TARBALL_STRIP_OPT=0
+    TARBALL_URL['x86_64']="https://partner-images.canonical.com/core/jammy/current/ubuntu-jammy-core-cloudimg-amd64-root.tar.gz"
+    TARBALL_SHA256['x86_64']="${sha256_map[ubuntu-jammy-core-cloudimg-amd64-root.tar.gz]}"
+    TARBALL_STRIP_OPT=0
 
-    TARBALL_URL['aarch64']="$PROOT_DISTRO_URL"
-    TARBALL_SHA256['aarch64']="$PROOT_DISTRO_CHECKSUM"
-
-    distro_setup() {
-        # Configure en_US.UTF-8 locale.
-        sed -i -E 's/#[[:space:]]?(en_US.UTF-8[[:space:]]+UTF-8)/\1/g' ./etc/locale.gen
-        run_proot_cmd DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
-    }
 EOF
+    echo "ubuntu.sh file overwritten and SHA256 values updated."
 }
 
 base_setup() {


### PR DESCRIPTION
replaces the proot ubuntu distro file with a modified version calling on current jammy ubuntu from canonical. Dynamically fills sha256 tarball values from canonical website. 

No need to hardcode values.